### PR TITLE
Fix ActiveRecordSupport.temperature? to consider both measures of the high and low temps.

### DIFF
--- a/lib/weather_base/active_record_support.rb
+++ b/lib/weather_base/active_record_support.rb
@@ -121,11 +121,6 @@ module WeatherBase #:nodoc:
       return !( precip_inches.nil? || precip_cm.nil? )
     end
     
-    #Does this record contain any temperature data?
-    def temperatures?
-      return !( high_temp_f.nil? || low_temp_f.nil? )
-    end
-
     #Returns a LengthMappable array of monthly precip data.
     def precip
       precips = []
@@ -146,6 +141,11 @@ module WeatherBase #:nodoc:
       return precips.extend(LengthMappable)
     end
     
+    #Does this record contain any temperature data?
+    def temperatures?
+      high? || low?
+    end
+
     #Is there high temperature data with this record?
     def high?
       return !(high_temp_f.nil? || high_temp_c.nil?)


### PR DESCRIPTION
No need for return as it's implicit in ruby.
